### PR TITLE
fix: コメントが長い際にはみ出ず、縦にスクロールできるようになった

### DIFF
--- a/components/CoffeeCard.vue
+++ b/components/CoffeeCard.vue
@@ -81,6 +81,7 @@ export default Vue.extend({
   height: 400px;
   .card-content {
     height: 340px;
+    overflow-y: scroll;
   }
   .card-footer-item {
     height: 60px;

--- a/components/CoffeeCards.vue
+++ b/components/CoffeeCards.vue
@@ -29,11 +29,11 @@ export default Vue.extend({
     showDetails: Boolean,
     existMore: { type: Boolean, default: false },
   },
-  methods:{
-    viewMore():void{
-      this.$emit("view-more-button-click")
-    }
-  }
+  methods: {
+    viewMore(): void {
+      this.$emit("view-more-button-click");
+    },
+  },
 });
 </script>
 
@@ -45,10 +45,11 @@ export default Vue.extend({
 
   .horizonal-item {
     display: inline-block;
-    width: 80%;
+    width: 90%;
     max-width: 25em;
-    margin: 0em 2em 1em 0em;
+    padding-right: 10%;
     vertical-align: top;
+    white-space: normal;
   }
   .view-more-box {
     margin: 0;

--- a/components/ReviewCard.vue
+++ b/components/ReviewCard.vue
@@ -6,9 +6,7 @@
           {{ review.coffee.bean.fullName }}
         </nuxt-link>
       </p>
-      <review-card-body
-        :review="review"
-      ></review-card-body>
+      <review-card-body :review="review"></review-card-body>
     </div>
     <footer class="card-footer">
       <modal-with-button
@@ -117,6 +115,7 @@ export default Vue.extend({
   height: 400px;
   .card-content {
     height: 340px;
+    overflow-y: scroll;
   }
   .card-footer {
     height: 60px;

--- a/components/ReviewCardBody.vue
+++ b/components/ReviewCardBody.vue
@@ -7,23 +7,21 @@
       </UsersName>
     </p>
     <div>
-        <ul>
-          <li class="date">
-            記入日 : <ConvertTime :time="review.createdAt" />
-          </li>
-          <li>苦さ : {{ review.bitterness }}</li>
-          <li>濃さ : {{ review.strongness }}</li>
-          <li>また飲みたいか : {{ review.wantRepeat }}</li>
-          <li>役割 : {{ review.situation }}</li>
-          <li v-if="review.feeling">備考・感想 : {{ review.feeling }}</li>
-        </ul>
+      <ul>
+        <li class="date">記入日 : <ConvertTime :time="review.createdAt" /></li>
+        <li>苦さ : {{ review.bitterness }}</li>
+        <li>濃さ : {{ review.strongness }}</li>
+        <li>また飲みたいか : {{ review.wantRepeat }}</li>
+        <li>役割 : {{ review.situation }}</li>
+        <li v-if="review.feeling">備考・感想 : {{ review.feeling }}</li>
+      </ul>
     </div>
   </div>
 </template>
 
 <script lang="ts">
 import Vue, { PropType } from "vue";
-import { Review} from "~/types/models";
+import { Review } from "~/types/models";
 export default Vue.extend({
   props: {
     review: { type: Object as PropType<Review>, default: null },

--- a/components/ReviewCards.vue
+++ b/components/ReviewCards.vue
@@ -43,9 +43,10 @@ export default Vue.extend({
     /* 横スクロール用 */
     display: inline-block;
     vertical-align: top;
-    width: 80%;
+    width: 90%;
     max-width: 25em;
-    margin: 0em 2em 1em 0em;
+    padding-right: 10%;
+    white-space: normal;
   }
   .view-more-box {
     margin: 0;
@@ -61,11 +62,5 @@ export default Vue.extend({
       -webkit-transform: translateY(-50%) translateX(-50%);
     }
   }
-}
-
-.view-more {
-  display: inline-block;
-  margin-top: 2%;
-  font-size: 3em;
 }
 </style>


### PR DESCRIPTION
ユーザーページなど、コーヒー・レビューカードが長くなった際にメッセージ内でスクロールができるようになった。
![image](https://user-images.githubusercontent.com/45584045/108211054-9cbef180-716f-11eb-8716-e0b359ae18c9.png)
![image](https://user-images.githubusercontent.com/45584045/108211062-9e88b500-716f-11eb-9983-a470bb998c6a.png)
