### PR TITLE
動的ルーティングでリロード時に404にならない

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -118,4 +118,8 @@ export default {
   router: {
     middleware: ["auth", "logined", "notLogin"],
   },
+
+  generate: {
+    fallback: true,
+  },
 };

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -5,7 +5,11 @@ export default {
    ** Nuxt rendering mode
    ** See https://nuxtjs.org/api/configuration-mode
    */
-  mode: "spa",
+  ssr: false,
+
+  // Target (https://go.nuxtjs.dev/config-target)
+  target: "static",
+
   /*
    ** Nuxt target
    ** See https://nuxtjs.org/api/configuration-target


### PR DESCRIPTION
ユーザーページやレビュー作成ページでリロードしたときに404にならなくなった。
## やったこと
- nuxt.configにフォールバックを設定
- (直接は関係ないけど)Nuxt.config.jsの非推奨設定のmodeをtarget, ssrプロパティに変更

## 確認方法
https://fix-dynamic-rooting--higa-database.netlify.app/users/1
このブランチのデプロイで動的ルーティングしてる場所でリロード。