### PR TITLE
fix 大画面でカードの並びが崩れるのを修正

### DIFF
--- a/components/CoffeeCards.vue
+++ b/components/CoffeeCards.vue
@@ -45,9 +45,9 @@ export default Vue.extend({
 
   .horizonal-item {
     display: inline-block;
-    width: 90%;
+    width: 80%;
     max-width: 25em;
-    padding-right: 10%;
+    margin-right: 3em;
     vertical-align: top;
     white-space: normal;
   }

--- a/components/ReviewCards.vue
+++ b/components/ReviewCards.vue
@@ -40,12 +40,11 @@ export default Vue.extend({
   white-space: nowrap;
   -webkit-overflow-scrolling: touch;
   .horizonal-item {
-    /* 横スクロール用 */
     display: inline-block;
-    vertical-align: top;
-    width: 90%;
+    width: 80%;
     max-width: 25em;
-    padding-right: 10%;
+    margin-right: 3em;
+    vertical-align: top;
     white-space: normal;
   }
   .view-more-box {


### PR DESCRIPTION
タイトルの通り。デスクトップでマイページのコーヒー・レビューカードが崩れるのを修正